### PR TITLE
Support sudo for mounting

### DIFF
--- a/lib/file_system_utils/mount_fs.ex
+++ b/lib/file_system_utils/mount_fs.ex
@@ -63,7 +63,7 @@ defmodule FileSystemUtils.MountFS do
     Path to the device
   """
   @spec umount(String.t(), [sudo: boolean]) :: :ok | {:error, String.t()}
-  def umount(device_path, opts) do
+  def umount(device_path, opts \\ []) do
     with true <- File.exists?(device_path),
          {cmd, args} <- base_mount_command("umount", opts),
          {_result, err_code} <- System.cmd(cmd, args ++ [device_path], stderr_to_stdout: true) do


### PR DESCRIPTION
Support sudo with `sudo: true`, as in:

    FileSystemUtils.MountFS.mount("/dev/sdb2", "/media", sudo: true)
    FileSystemUtils.MountFS.umount("/media", sudo: true)

Is backwards compatible (code and behaviour) with a version of mount that takes a bistring for fstype, and a default arg on umount for the options.

This allows use of mount/unmount without running the whole app as root as long as sudo priveleges are setup correctly.